### PR TITLE
fix mobile view not full width, add some styling

### DIFF
--- a/src/components/SubtitleTable.tsx
+++ b/src/components/SubtitleTable.tsx
@@ -1,5 +1,5 @@
 
-import { Table, TableBody, TableCell, TableHead, TableRow} from '@mui/material';
+import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
 import { SubtitleData } from "@/components/Subtitle";
 
 export type SubtitleTableProps = {
@@ -8,6 +8,17 @@ export type SubtitleTableProps = {
     setPlayerTime: (time: number) => void,
     currentTimestamp?: number,
 };
+
+const formatTime = (time: number) => {
+    return new Date(time * 1000).toISOString().slice(11, 19);
+}
+
+const getBackGroundColor = (startTime: number, endTime: number, currentTimestamp?: number) => {
+    if (currentTimestamp && currentTimestamp >= startTime && currentTimestamp < endTime) {
+        return "yellow";
+    }
+    return "white";
+}
 
 
 const SubtitleTable = ({ subtitles, filter, currentTimestamp, setPlayerTime }: SubtitleTableProps) => {
@@ -23,24 +34,25 @@ const SubtitleTable = ({ subtitles, filter, currentTimestamp, setPlayerTime }: S
                 </TableRow>
             </TableHead>
             <TableBody>
-                {subtitlesToDisplay.map((subtitle, index) => {
-                    if (currentTimestamp && currentTimestamp >= subtitle.startTime && currentTimestamp < subtitle.endTime) {
-                        return (
-                            <TableRow key={index} style={{ backgroundColor: "yellow" }}>
-                                <TableCell>{subtitle.startTime}</TableCell>
-                                <TableCell>{subtitle.endTime}</TableCell>
-                                <TableCell>{subtitle.text}</TableCell>
-                            </TableRow>
-                        );
-                    }
-                    return (
-                        <TableRow key={index} onClick={() => setPlayerTime(subtitle.startTime)}>
-                            <TableCell>{subtitle.startTime}</TableCell>
-                            <TableCell>{subtitle.endTime}</TableCell>
-                            <TableCell>{subtitle.text}</TableCell>
-                        </TableRow>
-                    );
-                })}
+                {subtitlesToDisplay.map((subtitle, index) => (
+                    <TableRow
+                        key={index}
+                        sx={{
+                            backgroundColor: getBackGroundColor(subtitle.startTime, subtitle.endTime, currentTimestamp),
+                            cursor: "pointer",
+                            "&:hover": {
+                                backgroundColor: "lightgray",
+                            }
+                        }}
+                        onClick={() => setPlayerTime(subtitle.startTime)}
+                    >
+                        <TableCell component="th" scope="row">
+                            {formatTime(subtitle.startTime)}
+                        </TableCell>
+                        <TableCell>{formatTime(subtitle.endTime)}</TableCell>
+                        <TableCell>{subtitle.text}</TableCell>
+                    </TableRow>
+                ))}
             </TableBody>
         </Table>
     );

--- a/src/components/SubtitleTable.tsx
+++ b/src/components/SubtitleTable.tsx
@@ -41,7 +41,7 @@ const SubtitleTable = ({ subtitles, filter, currentTimestamp, setPlayerTime }: S
                             backgroundColor: getBackGroundColor(subtitle.startTime, subtitle.endTime, currentTimestamp),
                             cursor: "pointer",
                             "&:hover": {
-                                backgroundColor: "lightgray",
+                                backgroundColor: {xs: 'none', sm: 'lightgray'}
                             }
                         }}
                         onClick={() => setPlayerTime(subtitle.startTime)}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head />
-      <body>
+      <body style={{ position: "absolute"}}>
         <Main />
         <NextScript />
       </body>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -50,7 +50,7 @@ export default function Home() {
           </Typography>
           <YouTubeVideo onReady={setPlayer} />
           <p>Current Time: {timestamp.toFixed(2)} seconds</p>
-          <Button variant="outlined" onClick={handleCutterOpen}>Videoyu Kes</Button>
+          <Button variant="outlined" onClick={handleCutterOpen} sx={{ width: '25%' }}>Videoyu Kes</Button>
         </Stack>
       </Grid>
       <Grid item xs={12} md={6}>


### PR DESCRIPTION
- there was a problem in the mobile view, viewport was not full width. this is fixed by adding "display: 'absolute'" to the body.
- table was not seem to be clickable, hover effect added.
- time formatting added (hh:mm:ss), it may be more meaningful to the users